### PR TITLE
Pass options to viewer

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ if (program.viewer) {
   if (abs) program.viewer = path.resolve(program.viewer);
   viewer = require(program.viewer);
 } else {
-  viewer = require("report-viewer-default")
+  viewer = require("report-viewer-default")({
+    port: program.port || 9999
+  })
 }
 program.viewer = viewer
 


### PR DESCRIPTION
- Program port supplied to 'report-viewer-default' via the 'options' object
- Defaults to port '9999', for consistency with https://github.com/paulpflug/report-viewer/blob/master/lib/index.js#L25
- options.port is used by the 'report-viewer-default' to instantiate 'io()'
- Intended to address https://github.com/paulpflug/report-viewer/issues/1
- intended to be merged in conjunction with [PR #1](https://github.com/paulpflug/report-viewer-default/pull/1) of the [report-viewer-default](https://github.com/paulpflug/report-viewer-default) project
